### PR TITLE
Add missing API route for individual product pages

### DIFF
--- a/src/app/api/products/[id]/route.ts
+++ b/src/app/api/products/[id]/route.ts
@@ -1,0 +1,57 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient();
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const { id } = await params;
+    const productId = parseInt(id);
+
+    if (isNaN(productId)) {
+      return NextResponse.json(
+        { error: 'Invalid product ID' },
+        { status: 400 }
+      );
+    }
+
+    const product = await prisma.product.findUnique({
+      where: { id: productId },
+      include: {
+        user: {
+          select: { name: true }
+        },
+        category: {
+          select: { name: true }
+        },
+        reviews: {
+          include: {
+            user: {
+              select: { name: true }
+            }
+          }
+        }
+      }
+    });
+
+    if (!product) {
+      return NextResponse.json(
+        { error: 'Product not found' },
+        { status: 404 }
+      );
+    }
+
+    return NextResponse.json({ product });
+  } catch (error) {
+    console.error('Get product error:', error);
+    return NextResponse.json(
+      { error: 'Internal server error' },
+      { status: 500 }
+    );
+  } finally {
+    await prisma.$disconnect();
+  }
+}

--- a/src/app/product/[id]/page.tsx
+++ b/src/app/product/[id]/page.tsx
@@ -32,45 +32,14 @@ export default function ProductPage() {
   useEffect(() => {
     const fetchProduct = async () => {
       try {
-        // Mock data for different product IDs
-        const mockProducts: { [key: number]: Product } = {
-          1: {
-            id: 1,
-            name: 'Handcrafted Ceramic Bowl',
-            description: 'Beautiful handmade ceramic bowl perfect for serving or decoration. Made with love by local artisans.',
-            price: 45.99,
-            image: '/ceramic-bowls.webp',
-            user: { name: 'Maria Rodriguez' },
-            category: { name: 'Pottery' }
-          },
-          2: {
-            id: 2,
-            name: 'Wooden Animal Sculpture',
-            description: 'Unique hand-carved wooden animal sculpture. Each piece is one-of-a-kind and showcases traditional woodworking techniques.',
-            price: 89.99,
-            image: '/animal-wood.webp',
-            user: { name: 'Carlos Mendez' },
-            category: { name: 'Wood Carving' }
-          },
-          3: {
-            id: 3,
-            name: 'Artisan Jewelry Set',
-            description: 'Elegant handcrafted jewelry set featuring natural stones and silver. Perfect for special occasions or everyday wear.',
-            price: 125.50,
-            image: '/jewelry.webp',
-            user: { name: 'Ana Silva' },
-            category: { name: 'Jewelry' }
-          }
-        };
-        
-        const mockProduct = mockProducts[productId];
-        
-        if (!mockProduct) {
-          setError('Product not found');
-          return;
+        const response = await fetch(`/api/products/${productId}`);
+        const data = await response.json();
+
+        if (response.ok) {
+          setProduct(data.product);
+        } else {
+          setError(data.error || 'Product not found');
         }
-        
-        setProduct(mockProduct);
       } catch {
         setError('Failed to load product');
       } finally {


### PR DESCRIPTION
src/app/api/products/[id]/route.ts - I created an API route to retrieve individual products, because previously it used "many".
 
I modified src/app/product/[id]/page.tsx to make it a single product page.
 
Since it previously used mock data, it now connects to the real API /api/products/${productId}.