### PR TITLE
Fix product details not loading

### DIFF
--- a/src/app/api/products/[id]/route.ts
+++ b/src/app/api/products/[id]/route.ts
@@ -10,12 +10,16 @@ export async function GET(
     const { id } = await context.params; // ⬅️ must await params
     const product = await prisma.product.findUnique({
       where: { id: parseInt(id, 10) },
+      include: {
+        user: true,
+        category: true,
+      },
     });
 
     if (!product)
       return NextResponse.json({ error: "Product not found" }, { status: 404 });
 
-    return NextResponse.json(product);
+    return NextResponse.json({ product });
   } catch (error) {
     console.error("Error fetching product:", error);
     return NextResponse.json(


### PR DESCRIPTION
The product details page was showing "Product not found" because the API was returning data in the wrong format. Fixed the response to include user and category information so products display correctly.